### PR TITLE
⚡ [performance] Asynchronous UUID verification in ServerPreConnect

### DIFF
--- a/src/main/java/net/rafalohaki/veloauth/listener/AuthListener.java
+++ b/src/main/java/net/rafalohaki/veloauth/listener/AuthListener.java
@@ -425,7 +425,7 @@ public class AuthListener {
      * - Po połączeniu z auth server, onServerConnected uruchomi auto-transfer
      */
     @Subscribe(priority = Short.MAX_VALUE)
-    public void onServerPreConnect(ServerPreConnectEvent event) {
+    public EventTask onServerPreConnect(ServerPreConnectEvent event) {
         try {
             Player player = event.getPlayer();
             // NAPRAWIONE: Używamy getOriginalServer() zamiast getTarget()
@@ -436,20 +436,21 @@ public class AuthListener {
                     player.getUsername(), targetServerName);
 
             if (handleFirstConnection(event, player, targetServerName)) {
-                return;
+                return null;
             }
 
             // ✅ JEŚLI TO AUTH SERVER - SPRAWDŹ DODATKOWO AUTORYZACJĘ
             if (handleAuthServerConnection(event, player, targetServerName)) {
-                return;
+                return null;
             }
 
             // ✅ JEŚLI TO BACKEND - SPRAWDŹ AUTORYZACJĘ + SESJĘ + CACHE
-            verifyBackendConnection(event, player, targetServerName);
+            return EventTask.resumeWhenComplete(verifyBackendConnectionAsync(event, player, targetServerName));
 
         } catch (Exception e) {
             logger.error("Błąd w ServerPreConnect", e);
             event.setResult(ServerPreConnectEvent.ServerResult.denied());
+            return null;
         }
     }
 
@@ -507,7 +508,7 @@ public class AuthListener {
         return false;
     }
 
-    private void verifyBackendConnection(ServerPreConnectEvent event, Player player, String targetServerName) {
+    private CompletableFuture<Void> verifyBackendConnectionAsync(ServerPreConnectEvent event, Player player, String targetServerName) {
         String playerIp = PlayerAddressUtils.getPlayerIp(player);
         boolean isAuthorized = authCache.isPlayerAuthorized(player.getUniqueId(), playerIp);
 
@@ -515,16 +516,22 @@ public class AuthListener {
         boolean hasActiveSession = authCache.hasActiveSession(player.getUniqueId(), player.getUsername(),
                 playerIp);
 
-        // WERYFIKUJ UUID z bazą danych dla maksymalnego bezpieczeństwa - delegate to handler
-        boolean uuidMatches = uuidVerificationHandler.verifyPlayerUuid(player);
-
-        if (!isAuthorized || !hasActiveSession || !uuidMatches) {
-            handleUnauthorizedConnection(event, player, targetServerName, isAuthorized, hasActiveSession, uuidMatches, playerIp);
-        } else {
-            // ✅ WSZYSTKIE WERYFIKACJE PRZESZŁY - POZWÓL
-            logger.debug("\u2705 Autoryzowany gracz {} idzie na {} (sesja: OK, UUID: OK)",
-                    player.getUsername(), targetServerName);
-        }
+        // WERYFIKUJ UUID z bazą danych dla maksymalnego bezpieczeństwa - delegate to handler (ASYNC)
+        return uuidVerificationHandler.verifyPlayerUuid(player)
+                .thenAccept(uuidMatches -> {
+                    if (!isAuthorized || !hasActiveSession || !uuidMatches) {
+                        handleUnauthorizedConnection(event, player, targetServerName, isAuthorized, hasActiveSession, uuidMatches, playerIp);
+                    } else {
+                        // ✅ WSZYSTKIE WERYFIKACJE PRZESZŁY - POZWÓL
+                        logger.debug("\u2705 Autoryzowany gracz {} idzie na {} (sesja: OK, UUID: OK)",
+                                player.getUsername(), targetServerName);
+                    }
+                })
+                .exceptionally(throwable -> {
+                    logger.error("Error during async backend connection verification for {}", player.getUsername(), throwable);
+                    event.setResult(ServerPreConnectEvent.ServerResult.denied());
+                    return null;
+                });
     }
 
     private void handleUnauthorizedConnection(ServerPreConnectEvent event, Player player, String targetServerName,

--- a/src/main/java/net/rafalohaki/veloauth/listener/UuidVerificationHandler.java
+++ b/src/main/java/net/rafalohaki/veloauth/listener/UuidVerificationHandler.java
@@ -13,6 +13,7 @@ import org.slf4j.MarkerFactory;
 
 import java.time.Instant;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Handles UUID verification logic for player authentication.
@@ -53,16 +54,16 @@ public class UuidVerificationHandler {
      * Premium players skip verification as they don't need to be registered.
      *
      * @param player Player to verify
-     * @return true if verification passes
+     * @return CompletableFuture that completes with true if verification passes
      */
-    public boolean verifyPlayerUuid(Player player) {
+    public CompletableFuture<Boolean> verifyPlayerUuid(Player player) {
         try {
             if (player.isOnlineMode()) {
-                return handlePremiumPlayer(player);
+                return CompletableFuture.completedFuture(handlePremiumPlayer(player));
             }
-            return verifyCrackedPlayerUuid(player);
+            return verifyCrackedPlayerUuidAsync(player);
         } catch (Exception e) {
-            return handleVerificationError(player, e);
+            return CompletableFuture.completedFuture(handleVerificationError(player, e));
         }
     }
 
@@ -73,18 +74,23 @@ public class UuidVerificationHandler {
         return true;
     }
 
-    private boolean verifyCrackedPlayerUuid(Player player) {
-        try {
-            var dbResult = databaseManager.findPlayerByNickname(player.getUsername()).join();
+    private CompletableFuture<Boolean> verifyCrackedPlayerUuidAsync(Player player) {
+        return databaseManager.findPlayerByNickname(player.getUsername())
+                .thenApply(dbResult -> {
+                    if (dbResult.isDatabaseError()) {
+                        return handleDatabaseVerificationError(player, dbResult);
+                    }
 
-            if (dbResult.isDatabaseError()) {
-                return handleDatabaseVerificationError(player, dbResult);
-            }
-
-            return performUuidVerification(player, dbResult.getValue());
-        } catch (Exception e) {
-            return handleAsyncVerificationError(player, e);
-        }
+                    return performUuidVerification(player, dbResult.getValue());
+                })
+                .exceptionally(e -> {
+                    // Extract cause if it's a CompletionException
+                    Throwable cause = e.getCause() != null ? e.getCause() : e;
+                    if (cause instanceof Exception ex) {
+                        return handleAsyncVerificationError(player, ex);
+                    }
+                    return handleAsyncVerificationError(player, new Exception(cause));
+                });
     }
 
     private boolean handleDatabaseVerificationError(Player player, DbResult<RegisteredPlayer> dbResult) {

--- a/src/test/java/net/rafalohaki/veloauth/listener/UuidVerificationHandlerTest.java
+++ b/src/test/java/net/rafalohaki/veloauth/listener/UuidVerificationHandlerTest.java
@@ -1,0 +1,143 @@
+package net.rafalohaki.veloauth.listener;
+
+import com.velocitypowered.api.proxy.Player;
+import net.rafalohaki.veloauth.cache.AuthCache;
+import net.rafalohaki.veloauth.database.DatabaseManager;
+import net.rafalohaki.veloauth.database.DatabaseManager.DbResult;
+import net.rafalohaki.veloauth.model.RegisteredPlayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UuidVerificationHandlerTest {
+
+    @Mock
+    private DatabaseManager databaseManager;
+
+    @Mock
+    private AuthCache authCache;
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private Player player;
+
+    private UuidVerificationHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new UuidVerificationHandler(databaseManager, authCache, logger);
+    }
+
+    @Test
+    void shouldReturnTrueForPremiumPlayer() {
+        // Given
+        when(player.isOnlineMode()).thenReturn(true);
+
+        // When
+        boolean result = handler.verifyPlayerUuid(player).join();
+
+        // Then
+        assertTrue(result);
+        verify(databaseManager, never()).findPlayerByNickname(anyString());
+    }
+
+    @Test
+    void shouldReturnTrueWhenUuidMatches() {
+        // Given
+        String username = "testplayer";
+        UUID uuid = UUID.randomUUID();
+        when(player.isOnlineMode()).thenReturn(false);
+        when(player.getUsername()).thenReturn(username);
+        when(player.getUniqueId()).thenReturn(uuid);
+
+        RegisteredPlayer dbPlayer = new RegisteredPlayer();
+        dbPlayer.setNickname(username);
+        dbPlayer.setUuid(uuid.toString());
+
+        when(databaseManager.findPlayerByNickname(username))
+                .thenReturn(CompletableFuture.completedFuture(DbResult.success(dbPlayer)));
+
+        // When
+        boolean result = handler.verifyPlayerUuid(player).join();
+
+        // Then
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldReturnFalseOnDatabaseError() {
+        // Given
+        String username = "testplayer";
+        when(player.isOnlineMode()).thenReturn(false);
+        when(player.getUsername()).thenReturn(username);
+
+        when(databaseManager.findPlayerByNickname(username))
+                .thenReturn(CompletableFuture.completedFuture(DbResult.databaseError("DB error")));
+
+        // When
+        boolean result = handler.verifyPlayerUuid(player).join();
+
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldReturnTrueInConflictMode() {
+        // Given
+        String username = "testplayer";
+        when(player.isOnlineMode()).thenReturn(false);
+        when(player.getUsername()).thenReturn(username);
+
+        RegisteredPlayer dbPlayer = new RegisteredPlayer();
+        dbPlayer.setNickname(username);
+        dbPlayer.setUuid(UUID.randomUUID().toString()); // Different UUID
+        dbPlayer.setConflictMode(true);
+
+        when(databaseManager.findPlayerByNickname(username))
+                .thenReturn(CompletableFuture.completedFuture(DbResult.success(dbPlayer)));
+
+        // When
+        boolean result = handler.verifyPlayerUuid(player).join();
+
+        // Then
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldReturnFalseOnUuidMismatch() {
+        // Given
+        String username = "testplayer";
+        UUID playerUuid = UUID.randomUUID();
+        UUID dbUuid = UUID.randomUUID();
+        when(player.isOnlineMode()).thenReturn(false);
+        when(player.getUsername()).thenReturn(username);
+        when(player.getUniqueId()).thenReturn(playerUuid);
+
+        RegisteredPlayer dbPlayer = new RegisteredPlayer();
+        dbPlayer.setNickname(username);
+        dbPlayer.setUuid(dbUuid.toString());
+        dbPlayer.setConflictMode(false);
+
+        when(databaseManager.findPlayerByNickname(username))
+                .thenReturn(CompletableFuture.completedFuture(DbResult.success(dbPlayer)));
+
+        // When
+        boolean result = handler.verifyPlayerUuid(player).join();
+
+        // Then
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
### ⚡ Performance Optimization: Asynchronous UUID Verification

#### What
Refactored the `UuidVerificationHandler` and its call-site in `AuthListener` to perform UUID verification asynchronously.

#### Why
The previous implementation used `.join()` on a `CompletableFuture` within the `ServerPreConnectEvent` handler. This blocked Velocity's Netty IO threads while waiting for database responses, which could lead to performance degradation and reduced proxy responsiveness, especially under high load or slow database connectivity.

#### Improvements
- **Non-blocking I/O:** The IO thread is now released back to the pool immediately after the database request is initiated and is resumed only when the result is available.
- **Idiomatic Velocity API usage:** Leverages `EventTask` for asynchronous event handling, following proxy best practices.
- **Enhanced testability:** Added a new test suite for `UuidVerificationHandler` that covers various authentication scenarios.

#### Verification Results
- **Unit Tests:** New `UuidVerificationHandlerTest` covers premium/cracked/conflict scenarios.
- **Static Analysis:** Confirmed removal of blocking `.join()` calls in the critical path via `grep`.
- **Code Review:** The solution was reviewed and rated as correct, following framework-specific patterns.

---
*PR created automatically by Jules for task [10572191989155619377](https://jules.google.com/task/10572191989155619377) started by @rafalohaki*