### PR TITLE
🧹 chore: remove unused Matcher import from Messages.java

### DIFF
--- a/src/main/java/net/rafalohaki/veloauth/i18n/Messages.java
+++ b/src/main/java/net/rafalohaki/veloauth/i18n/Messages.java
@@ -14,7 +14,6 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.concurrent.ConcurrentHashMap;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**


### PR DESCRIPTION
🎯 **What:** Removed an unused import `java.util.regex.Matcher` from `src/main/java/net/rafalohaki/veloauth/i18n/Messages.java`.
💡 **Why:** Reduces noise and improves code health without affecting functionality.
✅ **Verification:** Verified that the code compiles successfully (`mvn compile`) and all tests pass (`mvn test`).
✨ **Result:** Cleaned up the import list in `Messages.java`.

---
*PR created automatically by Jules for task [17985489029173152511](https://jules.google.com/task/17985489029173152511) started by @rafalohaki*