### PR TITLE
fix: resolve incorrect premium routing for cracked players and standardize allow-cracked-on-prem-nicks behavior

### DIFF
--- a/src/main/java/net/rafalohaki/veloauth/listener/AuthListener.java
+++ b/src/main/java/net/rafalohaki/veloauth/listener/AuthListener.java
@@ -338,7 +338,8 @@ public class AuthListener {
         }
 
         boolean playerExistsInDb = dbResult.getValue() != null 
-            || databaseManager.getPremiumUuidDao().findByNickname(username).isPresent();
+            || (result.premium() && settings.isAllowCrackedOnPremiumNicks() 
+                && databaseManager.getPremiumUuidDao().findByNickname(username).isPresent());
         setPremiumLoginMode(event, username, result.premium(), playerExistsInDb);
     }
 

--- a/src/main/java/net/rafalohaki/veloauth/listener/AuthListener.java
+++ b/src/main/java/net/rafalohaki/veloauth/listener/AuthListener.java
@@ -337,7 +337,8 @@ public class AuthListener {
             return;
         }
 
-        boolean playerExistsInDb = dbResult.getValue() != null;
+        boolean playerExistsInDb = dbResult.getValue() != null 
+            || databaseManager.getPremiumUuidDao().findByNickname(username).isPresent();
         setPremiumLoginMode(event, username, result.premium(), playerExistsInDb);
     }
 


### PR DESCRIPTION
this PR fixes inconsistent premium routing where resolver-detected premium accounts were sometimes treated as cracked sessions.

behavior matrix for validation:
| Scenario   | allow-cracked-on-prem-nicks | System State                | Premium Account Behavior                                          | Cracked (same premium name)                        | Cracked (unique name) | Notes                                                            |
| ---------- | --------------------------- | --------------------------- | ----------------------------------------------------------------- | -------------------------------------------------- | --------------------- | ---------------------------------------------------------------- |
| BEFORE FIX | false                       | broken / misclassified auth | treated as premium (no register prompt)                           | rejected / premium protection active               | register required     | behaves mostly correct                                           |
| BEFORE FIX | true                        | broken / misclassified auth | ⚠️ resolved as PREMIUM but forced offline mode (`PREMIUM BYPASS`) | ⚠️ register triggered despite existing premium record | register required     | mismatch: resolver sees premium but flow still routes as cracked |
| AFTER FIX  | false                       | correct premium routing     | treated as premium (no register prompt)                           | rejected / premium protection active               | register required     | stable + correct                                                 |
| AFTER FIX  | true                        | correct premium routing     | treated as premium (no register prompt)                           | rejected / premium protection active               | register required     | stable + correct                                                 |
