### PR TITLE
Don't persist resolver-sourced Mojang UUIDs during offline auth (PostAuthFlow)

### DIFF
--- a/src/main/java/net/rafalohaki/veloauth/command/PostAuthFlow.java
+++ b/src/main/java/net/rafalohaki/veloauth/command/PostAuthFlow.java
@@ -5,8 +5,11 @@ import net.rafalohaki.veloauth.database.DatabaseManager;
 import net.rafalohaki.veloauth.model.CachedAuthUser;
 import net.rafalohaki.veloauth.model.RegisteredPlayer;
 import net.rafalohaki.veloauth.util.PlayerAddressUtils;
+import net.rafalohaki.veloauth.util.UuidUtils;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
+
+import java.util.UUID;
 
 /**
  * Shared post-authentication flow used by both LoginCommand and RegisterCommand.
@@ -41,9 +44,10 @@ final class PostAuthFlow {
 
         // Offline auth paths (/login and /register) prove only password ownership for the
         // offline backend UUID. They must never persist or cache a resolver-sourced Mojang UUID
-        // as authoritative premium identity; only the online-mode GameProfileRequestEvent
-        // reconciliation path has a Mojang-verified session.
-        CachedAuthUser cachedUser = CachedAuthUser.fromRegisteredPlayer(player, isPremium);
+        // as authoritative premium identity. Reuse only an already-stored AUTH.PREMIUMUUID,
+        // which can be authoritative because it was written by Mojang-verified reconciliation.
+        CachedAuthUser cachedUser = CachedAuthUser.fromRegisteredPlayer(
+                player, isPremium, storedPremiumUuid(player, isPremium));
 
         Player p = authContext.player();
         ctx.authCache().authorize(p.getUniqueId(), cachedUser, authContext.username(),
@@ -84,5 +88,12 @@ final class PostAuthFlow {
                     return false;
         });
         return true;
+    }
+
+    private static UUID storedPremiumUuid(RegisteredPlayer player, boolean isPremium) {
+        if (!isPremium) {
+            return null;
+        }
+        return UuidUtils.parseUuidSafely(player.getPremiumUuid());
     }
 }

--- a/src/main/java/net/rafalohaki/veloauth/command/PostAuthFlow.java
+++ b/src/main/java/net/rafalohaki/veloauth/command/PostAuthFlow.java
@@ -1,16 +1,12 @@
 package net.rafalohaki.veloauth.command;
 
 import com.velocitypowered.api.proxy.Player;
-import net.rafalohaki.veloauth.cache.AuthCache;
 import net.rafalohaki.veloauth.database.DatabaseManager;
 import net.rafalohaki.veloauth.model.CachedAuthUser;
 import net.rafalohaki.veloauth.model.RegisteredPlayer;
 import net.rafalohaki.veloauth.util.PlayerAddressUtils;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
-
-import java.util.Optional;
-import java.util.UUID;
 
 /**
  * Shared post-authentication flow used by both LoginCommand and RegisterCommand.
@@ -43,13 +39,11 @@ final class PostAuthFlow {
 
         boolean isPremium = Boolean.TRUE.equals(premiumResult.getValue());
 
-        // Defense-in-depth: persist PREMIUMUUID for premium players who ended up in offline path
-        UUID premiumUuid = resolvePremiumUuid(ctx, authContext.player());
-        if (!persistPremiumUuid(ctx, authContext, player, isPremium, premiumUuid)) {
-            return false;
-        }
-
-        CachedAuthUser cachedUser = CachedAuthUser.fromRegisteredPlayer(player, isPremium, premiumUuid);
+        // Offline auth paths (/login and /register) prove only password ownership for the
+        // offline backend UUID. They must never persist or cache a resolver-sourced Mojang UUID
+        // as authoritative premium identity; only the online-mode GameProfileRequestEvent
+        // reconciliation path has a Mojang-verified session.
+        CachedAuthUser cachedUser = CachedAuthUser.fromRegisteredPlayer(player, isPremium);
 
         Player p = authContext.player();
         ctx.authCache().authorize(p.getUniqueId(), cachedUser, authContext.username(),
@@ -88,80 +82,7 @@ final class PostAuthFlow {
                             "Unexpected conflict-state cleanup failure for {} after {}",
                             authContext.username(), operationName, throwable);
                     return false;
-                });
+        });
         return true;
-    }
-
-    private static boolean persistPremiumUuid(CommandContext ctx, AuthenticationContext authContext,
-                                              RegisteredPlayer player, boolean isPremium,
-                                              UUID premiumUuid) {
-        if (!isPremium || player.getPremiumUuid() != null || premiumUuid == null) {
-            return true;
-        }
-
-        player.setPremiumUuid(premiumUuid.toString());
-
-        try {
-            var savePlayerResult = ctx.databaseManager().savePlayer(player).join();
-            if (ctx.handleDatabaseError(savePlayerResult, authContext.player(),
-                    "Persist premium UUID in AUTH table")) {
-                return false;
-            }
-            if (!Boolean.TRUE.equals(savePlayerResult.getValue())) {
-                logPremiumUuidFailure(ctx, authContext.username(),
-                        "AUTH table update returned false while persisting PREMIUMUUID");
-                ctx.sendDatabaseErrorMessage(authContext.player());
-                return false;
-            }
-
-            var savePremiumUuidResult = ctx.databaseManager()
-                    .savePremiumUuid(authContext.username(), premiumUuid)
-                    .join();
-            if (ctx.handleDatabaseError(savePremiumUuidResult, authContext.player(),
-                    "Sync PREMIUM_UUIDS table")) {
-                return false;
-            }
-            if (!Boolean.TRUE.equals(savePremiumUuidResult.getValue())) {
-                logPremiumUuidFailure(ctx, authContext.username(),
-                        "PREMIUM_UUIDS sync returned false");
-                ctx.sendDatabaseErrorMessage(authContext.player());
-                return false;
-            }
-        } catch (java.util.concurrent.CompletionException e) {
-            logPremiumUuidFailure(ctx, authContext.username(), "Unexpected async premium UUID failure", e);
-            ctx.sendDatabaseErrorMessage(authContext.player());
-            return false;
-        }
-
-        if (ctx.logger().isInfoEnabled()) {
-            ctx.logger().info(AUTH_MARKER,
-                    "Persisted PREMIUMUUID for {} in AUTH and PREMIUM_UUIDS tables",
-                    authContext.username());
-        }
-        return true;
-    }
-
-    private static void logPremiumUuidFailure(CommandContext ctx, String username, String message) {
-        if (ctx.logger().isWarnEnabled()) {
-            ctx.logger().warn(AUTH_MARKER, "{} for {}", message, username);
-        }
-    }
-
-    private static void logPremiumUuidFailure(CommandContext ctx, String username,
-                                              String message, Throwable throwable) {
-        if (ctx.logger().isErrorEnabled()) {
-            ctx.logger().error(AUTH_MARKER, "{} for {}", message, username, throwable);
-        }
-    }
-
-    /**
-     * Resolves premium UUID from AuthCache for the given player.
-     *
-     * @return premium UUID if available, null otherwise
-     */
-    private static UUID resolvePremiumUuid(CommandContext ctx, Player player) {
-        return Optional.ofNullable(ctx.authCache().getPremiumStatus(player.getUsername()))
-                .map(AuthCache.PremiumCacheEntry::getPremiumUuid)
-                .orElse(null);
     }
 }

--- a/src/main/java/net/rafalohaki/veloauth/database/DatabaseManager.java
+++ b/src/main/java/net/rafalohaki/veloauth/database/DatabaseManager.java
@@ -1050,7 +1050,8 @@ public class DatabaseManager {
             return false;
         }
 
-        // Primary: premiumUuid is the authoritative premium marker (set by PostAuthFlow)
+        // Primary: premiumUuid is the authoritative premium marker (set only by
+        // reconcileVerifiedPremiumProfile after Mojang verification, never by offline auth).
         String premiumUuid = player.getPremiumUuid();
         if (premiumUuid != null && !premiumUuid.isEmpty()) {
             return true;

--- a/src/test/java/net/rafalohaki/veloauth/command/CommandFlowFixesTest.java
+++ b/src/test/java/net/rafalohaki/veloauth/command/CommandFlowFixesTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -306,7 +307,7 @@ class CommandFlowFixesTest {
     }
 
     @Test
-    void testPostAuthFlow_WhenAuthTablePremiumUuidPersistReturnsFalse_ReturnsFalseWithoutTransfer() {
+    void testPostAuthFlow_DoesNotPersistResolverSourcedPremiumUuidFromOfflinePath() {
         UUID premiumUuid = UUID.randomUUID();
         RegisteredPlayer registeredPlayer = createRegisteredPlayer(TEST_PLAYER_NAME, playerUuid, hash("secret123"));
         AuthenticationContext authContext = new AuthenticationContext(
@@ -319,46 +320,19 @@ class CommandFlowFixesTest {
         authCache.addPremiumPlayer(TEST_PLAYER_NAME, premiumUuid);
         databaseManager.setPremiumResult(TEST_PLAYER_NAME,
                 CompletableFuture.completedFuture(DatabaseManager.DbResult.success(true)));
-        databaseManager.enqueueSavePlayerResult(DatabaseManager.DbResult.success(false));
-
-        boolean result = PostAuthFlow.execute(inlineContext, authContext, registeredPlayer, "logged in");
-
-        assertFalse(result);
-        assertTrue(authCache.findAuthorizedPlayer(playerUuid).isEmpty());
-        verify(connectionManager, never()).transferToBackend(player);
-
-        ArgumentCaptor<Component> messagesCaptor = ArgumentCaptor.forClass(Component.class);
-        verify(player, atLeastOnce()).sendMessage(messagesCaptor.capture());
-        assertTrue(capturedTexts(messagesCaptor).contains(messages.get("error.database.query")));
-    }
-
-    @Test
-    void testPostAuthFlow_WhenPremiumUuidSyncFails_ReturnsFalseWithoutTransfer() {
-        UUID premiumUuid = UUID.randomUUID();
-        RegisteredPlayer registeredPlayer = createRegisteredPlayer(TEST_PLAYER_NAME, playerUuid, hash("secret123"));
-        AuthenticationContext authContext = new AuthenticationContext(
-                player,
-                TEST_PLAYER_NAME,
-                player.getRemoteAddress().getAddress(),
-                registeredPlayer
-        );
-
-        authCache.addPremiumPlayer(TEST_PLAYER_NAME, premiumUuid);
-        databaseManager.setPremiumResult(TEST_PLAYER_NAME,
-                CompletableFuture.completedFuture(DatabaseManager.DbResult.success(true)));
-        databaseManager.enqueueSavePlayerResult(DatabaseManager.DbResult.success(true));
         databaseManager.setSavePremiumUuidResult(
-                CompletableFuture.completedFuture(DatabaseManager.DbResult.databaseError("premium sync failed")));
+                CompletableFuture.completedFuture(DatabaseManager.DbResult.databaseError("must not be called")));
+        when(connectionManager.transferToBackend(player)).thenReturn(true);
 
         boolean result = PostAuthFlow.execute(inlineContext, authContext, registeredPlayer, "logged in");
 
-        assertFalse(result);
-        assertTrue(authCache.findAuthorizedPlayer(playerUuid).isEmpty());
-        verify(connectionManager, never()).transferToBackend(player);
-
-        ArgumentCaptor<Component> messagesCaptor = ArgumentCaptor.forClass(Component.class);
-        verify(player, atLeastOnce()).sendMessage(messagesCaptor.capture());
-        assertTrue(capturedTexts(messagesCaptor).contains(messages.get("error.database.query")));
+        assertTrue(result);
+        assertNull(registeredPlayer.getPremiumUuid(),
+                "Offline auth must not promote resolver-sourced UUIDs into AUTH.PREMIUMUUID");
+        assertTrue(authCache.findAuthorizedPlayer(playerUuid).isPresent());
+        verify(connectionManager).transferToBackend(player);
+        assertFalse(databaseManager.wasSavePremiumUuidCalled(),
+                "PREMIUM_UUIDS sync must be reserved for Mojang-verified profile reconciliation");
     }
 
     @Test
@@ -524,6 +498,7 @@ class CommandFlowFixesTest {
                 CompletableFuture.completedFuture(DbResult.success(true));
         private CompletableFuture<DbResult<Boolean>> savePremiumUuidResult =
                 CompletableFuture.completedFuture(DbResult.success(true));
+        private boolean savePremiumUuidCalled;
         private CompletableFuture<Integer> totalRegisteredAccounts =
                 CompletableFuture.completedFuture(0);
         private CompletableFuture<Integer> totalPremiumAccounts =
@@ -558,6 +533,10 @@ class CommandFlowFixesTest {
 
         void setSavePremiumUuidResult(CompletableFuture<DbResult<Boolean>> result) {
             savePremiumUuidResult = result;
+        }
+
+        boolean wasSavePremiumUuidCalled() {
+            return savePremiumUuidCalled;
         }
 
         void setTotalRegisteredAccounts(CompletableFuture<Integer> result) {
@@ -606,6 +585,7 @@ class CommandFlowFixesTest {
 
         @Override
         public CompletableFuture<DbResult<Boolean>> savePremiumUuid(String username, UUID premiumUuid) {
+            savePremiumUuidCalled = true;
             return savePremiumUuidResult;
         }
 

--- a/src/test/java/net/rafalohaki/veloauth/command/CommandFlowFixesTest.java
+++ b/src/test/java/net/rafalohaki/veloauth/command/CommandFlowFixesTest.java
@@ -260,11 +260,7 @@ class CommandFlowFixesTest {
         // PostAuthFlow needs both a real ConnectionManager (transferToBackend → true) and an
         // AuthTimeoutScheduler (cancel on success). Inject a scheduler stub via reflection.
         when(connectionManager.transferToBackend(player)).thenReturn(true);
-        net.rafalohaki.veloauth.connection.AuthTimeoutScheduler scheduler =
-                mock(net.rafalohaki.veloauth.connection.AuthTimeoutScheduler.class);
-        Field schedulerField = VeloAuth.class.getDeclaredField("authTimeoutScheduler");
-        schedulerField.setAccessible(true);
-        schedulerField.set(plugin, scheduler);
+        injectAuthTimeoutScheduler();
 
         setExecutorShutdown(true); // run inline so assertions see the post-command state
         try {
@@ -307,7 +303,7 @@ class CommandFlowFixesTest {
     }
 
     @Test
-    void testPostAuthFlow_DoesNotPersistResolverSourcedPremiumUuidFromOfflinePath() {
+    void testPostAuthFlow_DoesNotPersistResolverSourcedPremiumUuidFromOfflinePath() throws Exception {
         UUID premiumUuid = UUID.randomUUID();
         RegisteredPlayer registeredPlayer = createRegisteredPlayer(TEST_PLAYER_NAME, playerUuid, hash("secret123"));
         AuthenticationContext authContext = new AuthenticationContext(
@@ -323,6 +319,7 @@ class CommandFlowFixesTest {
         databaseManager.setSavePremiumUuidResult(
                 CompletableFuture.completedFuture(DatabaseManager.DbResult.databaseError("must not be called")));
         when(connectionManager.transferToBackend(player)).thenReturn(true);
+        injectAuthTimeoutScheduler();
 
         boolean result = PostAuthFlow.execute(inlineContext, authContext, registeredPlayer, "logged in");
 
@@ -333,6 +330,14 @@ class CommandFlowFixesTest {
         verify(connectionManager).transferToBackend(player);
         assertFalse(databaseManager.wasSavePremiumUuidCalled(),
                 "PREMIUM_UUIDS sync must be reserved for Mojang-verified profile reconciliation");
+    }
+
+    private void injectAuthTimeoutScheduler() throws Exception {
+        net.rafalohaki.veloauth.connection.AuthTimeoutScheduler scheduler =
+                mock(net.rafalohaki.veloauth.connection.AuthTimeoutScheduler.class);
+        Field schedulerField = VeloAuth.class.getDeclaredField("authTimeoutScheduler");
+        schedulerField.setAccessible(true);
+        schedulerField.set(plugin, scheduler);
     }
 
     @Test

--- a/src/test/java/net/rafalohaki/veloauth/command/CommandFlowFixesTest.java
+++ b/src/test/java/net/rafalohaki/veloauth/command/CommandFlowFixesTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -327,9 +328,43 @@ class CommandFlowFixesTest {
         assertNull(registeredPlayer.getPremiumUuid(),
                 "Offline auth must not promote resolver-sourced UUIDs into AUTH.PREMIUMUUID");
         assertTrue(authCache.findAuthorizedPlayer(playerUuid).isPresent());
+        assertNull(authCache.findAuthorizedPlayer(playerUuid).orElseThrow().getPremiumUuid(),
+                "Offline auth cache must not store resolver-sourced UUIDs");
         verify(connectionManager).transferToBackend(player);
         assertFalse(databaseManager.wasSavePremiumUuidCalled(),
                 "PREMIUM_UUIDS sync must be reserved for Mojang-verified profile reconciliation");
+    }
+
+    @Test
+    void testPostAuthFlow_PreservesStoredVerifiedPremiumUuidInCache() throws Exception {
+        UUID storedPremiumUuid = UUID.randomUUID();
+        UUID resolverPremiumUuid = UUID.randomUUID();
+        RegisteredPlayer registeredPlayer = createRegisteredPlayer(TEST_PLAYER_NAME, playerUuid, hash("secret123"));
+        registeredPlayer.setPremiumUuid(storedPremiumUuid.toString());
+        AuthenticationContext authContext = new AuthenticationContext(
+                player,
+                TEST_PLAYER_NAME,
+                player.getRemoteAddress().getAddress(),
+                registeredPlayer
+        );
+
+        authCache.addPremiumPlayer(TEST_PLAYER_NAME, resolverPremiumUuid);
+        databaseManager.setPremiumResult(TEST_PLAYER_NAME,
+                CompletableFuture.completedFuture(DatabaseManager.DbResult.success(true)));
+        databaseManager.setSavePremiumUuidResult(
+                CompletableFuture.completedFuture(DatabaseManager.DbResult.databaseError("must not be called")));
+        when(connectionManager.transferToBackend(player)).thenReturn(true);
+        injectAuthTimeoutScheduler();
+
+        boolean result = PostAuthFlow.execute(inlineContext, authContext, registeredPlayer, "logged in");
+
+        CachedAuthUser cachedUser = authCache.findAuthorizedPlayer(playerUuid).orElseThrow();
+        assertTrue(result);
+        assertEquals(storedPremiumUuid, cachedUser.getPremiumUuid(),
+                "Offline auth may cache the verified premium UUID already stored in AUTH");
+        verify(connectionManager).transferToBackend(player);
+        assertFalse(databaseManager.wasSavePremiumUuidCalled(),
+                "Preserving stored AUTH.PREMIUMUUID must not trigger a new premium UUID sync");
     }
 
     private void injectAuthTimeoutScheduler() throws Exception {


### PR DESCRIPTION
### Motivation
- Prevent offline authentication from promoting resolver-sourced Mojang UUIDs into the authoritative premium identity and avoid performing database writes from the offline auth path.

### Description
- Remove premium UUID resolution and persistence from `PostAuthFlow.execute` so offline `/login` and `/register` flows no longer set or save resolver-sourced `PREMIUMUUID` and no longer call the premium UUID sync path. 
- Stop passing a resolver-sourced UUID into `CachedAuthUser.fromRegisteredPlayer` and add a clarifying comment that only Mojang-verified reconciliation sets the authoritative premium UUID. 
- Update `DatabaseManager.isPlayerPremiumRuntime` comment to reflect that `PREMIUMUUID` is set only by verified reconciliation. 
- Update tests in `CommandFlowFixesTest` and `StubDatabaseManager` to assert the offline flow does not set `PREMIUMUUID` and to track whether `savePremiumUuid` was invoked.

### Testing
- Ran the updated unit test `CommandFlowFixesTest::testPostAuthFlow_DoesNotPersistResolverSourcedPremiumUuidFromOfflinePath`, which passed. 
- Ran the project's affected unit tests after changes, and the modified test assertions succeeded (no database sync call observed for offline auth).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5628e7b3f083278b6553051ad7c86f)